### PR TITLE
fix: add package name for runtime module

### DIFF
--- a/modules/gallery/src/androidMain/kotlin/StoryBook.android.kt
+++ b/modules/gallery/src/androidMain/kotlin/StoryBook.android.kt
@@ -1,6 +1,8 @@
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import org.jetbrains.storytale.runtime.Story
+import org.jetbrains.storytale.runtime.buildStoryBook
 
 actual fun getStoryBook(): List<Story> = buildStoryBook {
   addStory(

--- a/modules/gallery/src/commonMain/kotlin/LazyStoryList.kt
+++ b/modules/gallery/src/commonMain/kotlin/LazyStoryList.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import org.jetbrains.storytale.runtime.Story
 
 @Composable
 fun LazyStoryList(

--- a/modules/gallery/src/commonMain/kotlin/StoryBook.kt
+++ b/modules/gallery/src/commonMain/kotlin/StoryBook.kt
@@ -1,1 +1,3 @@
+import org.jetbrains.storytale.runtime.Story
+
 expect fun getStoryBook(): List<Story>

--- a/modules/gallery/src/desktopMain/kotlin/StoryBook.desktop.kt
+++ b/modules/gallery/src/desktopMain/kotlin/StoryBook.desktop.kt
@@ -1,6 +1,8 @@
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import org.jetbrains.storytale.runtime.Story
+import org.jetbrains.storytale.runtime.buildStoryBook
 
 actual fun getStoryBook(): List<Story> = buildStoryBook {
   addStory(

--- a/modules/gallery/src/iosMain/kotlin/StoryBook.ios.kt
+++ b/modules/gallery/src/iosMain/kotlin/StoryBook.ios.kt
@@ -1,6 +1,8 @@
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import org.jetbrains.storytale.runtime.Story
+import org.jetbrains.storytale.runtime.buildStoryBook
 
 actual fun getStoryBook(): List<Story> = buildStoryBook {
   addStory(

--- a/modules/gallery/src/wasmJsMain/kotlin/StoryBook.wasmJs.kt
+++ b/modules/gallery/src/wasmJsMain/kotlin/StoryBook.wasmJs.kt
@@ -1,6 +1,8 @@
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import org.jetbrains.storytale.runtime.Story
+import org.jetbrains.storytale.runtime.buildStoryBook
 
 actual fun getStoryBook(): List<Story> = buildStoryBook {
   addStory(

--- a/modules/runtime/src/commonMain/kotlin/Story.kt
+++ b/modules/runtime/src/commonMain/kotlin/Story.kt
@@ -1,3 +1,5 @@
+package org.jetbrains.storytale.runtime
+
 import androidx.compose.runtime.Composable
 
 abstract class Story {

--- a/modules/runtime/src/commonMain/kotlin/StoryBuilder.kt
+++ b/modules/runtime/src/commonMain/kotlin/StoryBuilder.kt
@@ -1,3 +1,5 @@
+package org.jetbrains.storytale.runtime
+
 class StoryBuilder {
   val list = mutableListOf<Story>()
   fun addStory(story: Story) = list.add(story)


### PR DESCRIPTION
<img width="488" alt="image" src="https://github.com/Kotlin/Storytale/assets/31311826/57a0a573-7b65-4fbf-84de-7436c7a94c31">

I believe that we should add package name for runtime module, because this allows for a clearer representation of the APIs of the different modules (e.g. runtime, gallery)