### PR TITLE
Add support for List and Enum parameters

### DIFF
--- a/examples/src/commonMain/kotlin/PrimaryButton.kt
+++ b/examples/src/commonMain/kotlin/PrimaryButton.kt
@@ -2,19 +2,33 @@ import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 @Composable
 fun PrimaryButton(
-  text: String,
-  modifier: Modifier = Modifier,
-  onClick: () -> Unit = {},
-  enabled: Boolean = true,
+    text: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    enabled: Boolean = true,
+    size: PrimaryButtonSize = PrimaryButtonSize.Medium,
 ) {
-  Button(
-    modifier = modifier,
-    onClick = onClick,
-    enabled = enabled,
-  ) {
-    Text(text)
-  }
+    Button(
+        modifier = modifier,
+        onClick = onClick,
+        enabled = enabled,
+    ) {
+        Text(
+            text = text,
+            fontSize = when (size) {
+                PrimaryButtonSize.Small -> 12.sp
+                PrimaryButtonSize.Medium -> 14.sp
+                PrimaryButtonSize.Large -> 20.sp
+            },
+        )
+    }
+}
+
+enum class PrimaryButtonSize {
+    Small, Medium, Large,
 }

--- a/examples/src/commonStories/kotlin/ComposeLogo.story.kt
+++ b/examples/src/commonStories/kotlin/ComposeLogo.story.kt
@@ -4,17 +4,17 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.storytale.story
 
 val `ComposeLogo Default State` by story {
-  ComposeLogo()
+    ComposeLogo()
 }
 
 val `ComposeLogo Small` by story {
-  ComposeLogo(Modifier.size(300.dp))
+    ComposeLogo(Modifier.size(300.dp))
 }
 
 val `ComposeLogo Medium` by story {
-  ComposeLogo(Modifier.size(600.dp))
+    ComposeLogo(Modifier.size(600.dp))
 }
 
 val `ComposeLogo Large` by story {
-  ComposeLogo(Modifier.size(900.dp))
+    ComposeLogo(Modifier.size(900.dp))
 }

--- a/examples/src/commonStories/kotlin/PrimaryButton.story.kt
+++ b/examples/src/commonStories/kotlin/PrimaryButton.story.kt
@@ -1,19 +1,42 @@
 import org.jetbrains.compose.storytale.story
 
 val PrimaryButton by story {
-  val enabled by parameter(true)
-  val text by parameter("Click Me")
+    val size by parameter(PrimaryButtonSize.Medium)
+    val enabled by parameter(true)
+    val text by parameter("Click Me")
 
-  PrimaryButton(text = text, enabled = enabled)
+    PrimaryButton(text = text, enabled = enabled, size = size)
 }
 
 val `PrimaryButton Default State` by story {
-  PrimaryButton("Click Me")
+    PrimaryButton("Click Me")
 }
 
 val `PrimaryButton Disabled` by story {
-  PrimaryButton(
-    text = "Click Me",
-    enabled = false,
-  )
+    PrimaryButton(
+        text = "Click Me",
+        enabled = false,
+    )
+}
+
+val `PrimaryButton Food` by story {
+    val foodEmojiList = listOf(
+        "Apple 🍎",
+        "Banana 🍌",
+        "Cherry 🍒",
+        "Grapes 🍇",
+        "Strawberry 🍓",
+        "Watermelon 🍉",
+        "Pineapple 🍍",
+        "Pizza 🍕",
+        "Burger 🍔",
+        "Fries 🍟",
+        "Ice Cream 🍦",
+        "Cake 🍰",
+        "Coffee ☕",
+        "Beer 🍺",
+    )
+
+    val food by parameter(foodEmojiList)
+    PrimaryButton(text = food)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.jvm.target.validation.mode=ignore
 
 #Publication
- storytale.deploy.version=0.0.3-SNAPSHOT
+ storytale.deploy.version=0.0.4-SNAPSHOT

--- a/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/story/StoryParametersList.kt
+++ b/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/story/StoryParametersList.kt
@@ -4,10 +4,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlin.reflect.KClass
 import org.jetbrains.compose.storytale.StoryParameter
 import org.jetbrains.compose.storytale.gallery.story.parameters.BooleanParameterField
+import org.jetbrains.compose.storytale.gallery.story.parameters.ListParameter
 import org.jetbrains.compose.storytale.gallery.story.parameters.TextParameterField
 import org.jetbrains.compose.storytale.gallery.utils.cast
 
@@ -21,71 +24,97 @@ fun StoryParametersList(
         verticalArrangement = Arrangement.spacedBy(24.dp),
     ) {
         parameters.forEach { parameter ->
-            when (parameter.type) {
-                String::class -> TextParameterField(
-                    parameterName = parameter.name,
-                    state = parameter.state.cast(),
-                    toTypeOrNull = { toString() },
-                    label = "String",
-                    modifier = Modifier.fillMaxWidth(),
-                )
+            key(parameter) {
+                val label = parameter.label ?: parameter.type.toLabel()
+                val values = parameter.values
+                if (values != null) {
+                    ListParameter(
+                        parameterName = parameter.name,
+                        selectedValueIndex = parameter.state.cast(),
+                        values = values,
+                        label = label,
+                    )
+                } else {
+                    when (parameter.type) {
+                        String::class -> TextParameterField(
+                            parameterName = parameter.name,
+                            state = parameter.state.cast(),
+                            toTypeOrNull = { toString() },
+                            label = label,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
 
-                Boolean::class -> BooleanParameterField(
-                    parameterName = parameter.name,
-                    state = parameter.state.cast(),
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                        Boolean::class -> BooleanParameterField(
+                            parameterName = parameter.name,
+                            state = parameter.state.cast(),
+                            modifier = Modifier.fillMaxWidth(),
+                            label = label,
+                        )
 
-                Byte::class -> TextParameterField(
-                    parameterName = parameter.name,
-                    state = parameter.state.cast(),
-                    toTypeOrNull = { toByteOrNull() },
-                    label = "Byte",
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                        Byte::class -> TextParameterField(
+                            parameterName = parameter.name,
+                            state = parameter.state.cast(),
+                            toTypeOrNull = { toByteOrNull() },
+                            label = label,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
 
-                Short::class -> TextParameterField(
-                    parameterName = parameter.name,
-                    state = parameter.state.cast(),
-                    toTypeOrNull = { toShortOrNull() },
-                    label = "Short",
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                        Short::class -> TextParameterField(
+                            parameterName = parameter.name,
+                            state = parameter.state.cast(),
+                            toTypeOrNull = { toShortOrNull() },
+                            label = label,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
 
-                Int::class -> TextParameterField(
-                    parameterName = parameter.name,
-                    state = parameter.state.cast(),
-                    toTypeOrNull = { toIntOrNull() },
-                    label = "Int",
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                        Int::class -> TextParameterField(
+                            parameterName = parameter.name,
+                            state = parameter.state.cast(),
+                            toTypeOrNull = { toIntOrNull() },
+                            label = label,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
 
-                Long::class -> TextParameterField(
-                    parameterName = parameter.name,
-                    state = parameter.state.cast(),
-                    toTypeOrNull = { toLongOrNull() },
-                    label = "Long",
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                        Long::class -> TextParameterField(
+                            parameterName = parameter.name,
+                            state = parameter.state.cast(),
+                            toTypeOrNull = { toLongOrNull() },
+                            label = label,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
 
-                Float::class -> TextParameterField(
-                    parameterName = parameter.name,
-                    state = parameter.state.cast(),
-                    toTypeOrNull = { toFloatOrNull() },
-                    label = "Float",
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                        Float::class -> TextParameterField(
+                            parameterName = parameter.name,
+                            state = parameter.state.cast(),
+                            toTypeOrNull = { toFloatOrNull() },
+                            label = label,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
 
-                Double::class -> TextParameterField(
-                    parameterName = parameter.name,
-                    state = parameter.state.cast(),
-                    toTypeOrNull = { toDoubleOrNull() },
-                    label = "Double",
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                        Double::class -> TextParameterField(
+                            parameterName = parameter.name,
+                            state = parameter.state.cast(),
+                            toTypeOrNull = { toDoubleOrNull() },
+                            label = label,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
 
-                else -> error("Unsupported parameter type ${parameter.type}")
+                        else -> error("Unsupported parameter type ${parameter.type}")
+                    }
+                }
             }
         }
     }
+}
+
+private fun KClass<*>.toLabel(): String? = when (this) {
+    String::class -> "String"
+    Boolean::class -> "Boolean"
+    Byte::class -> "Byte"
+    Short::class -> "Short"
+    Int::class -> "Int"
+    Long::class -> "Long"
+    Float::class -> "Float"
+    Double::class -> "Double"
+    else -> simpleName
 }

--- a/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/story/parameters/BooleanParameterField.kt
+++ b/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/story/parameters/BooleanParameterField.kt
@@ -20,7 +20,8 @@ fun BooleanParameterField(
     parameterName: String,
     state: MutableState<Boolean>,
     modifier: Modifier = Modifier,
-    description: String = "",
+    label: String? = "",
+    description: String? = null,
 ) = Column(modifier = modifier) {
     var checked by state
     CenterRow {
@@ -32,14 +33,14 @@ fun BooleanParameterField(
                 overflow = TextOverflow.Ellipsis,
             )
             Gap(6.dp)
-            ParameterLabel("Boolean")
+            if (label != null && label.isNotBlank()) ParameterLabel(label)
         }
         SwitchButton(
             checked = checked,
             onValueChange = { checked = it },
         )
     }
-    if (description.isNotEmpty()) {
+    if (description != null && description.isNotBlank()) {
         Gap(12.dp)
         Text(
             text = description,

--- a/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/story/parameters/ListParameter.kt
+++ b/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/story/parameters/ListParameter.kt
@@ -1,0 +1,212 @@
+package org.jetbrains.compose.storytale.gallery.story.parameters
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.storytale.gallery.generated.resources.Res
+import org.jetbrains.compose.storytale.gallery.generated.resources.arrow_back
+import org.jetbrains.compose.storytale.gallery.ui.component.CenterRow
+import org.jetbrains.compose.storytale.gallery.ui.component.Chip
+import org.jetbrains.compose.storytale.gallery.ui.component.Gap
+import org.jetbrains.compose.storytale.gallery.ui.component.sheet.StoryBottomSheetDragHandle
+import org.jetbrains.compose.storytale.gallery.ui.theme.currentColorScheme
+import org.jetbrains.compose.storytale.gallery.ui.theme.currentTypography
+
+@Suppress("ktlint:compose:mutable-state-param-check")
+@Composable
+fun ListParameter(
+    parameterName: String,
+    selectedValueIndex: MutableState<Int>,
+    values: List<Any?>,
+    modifier: Modifier = Modifier,
+    label: String? = null,
+    description: String? = null,
+) = Column(modifier) {
+    var isSheetVisible by remember { mutableStateOf(false) }
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = selectedValueIndex.value)
+
+    CenterRow {
+        Text(
+            text = parameterName,
+            style = currentTypography.parameterText,
+        )
+        Gap(6.dp)
+        if (label != null && label.isNotBlank()) ParameterLabel(label)
+    }
+    Gap(12.dp)
+    Row {
+        Box(modifier = Modifier.weight(1f)) {
+            LazyRow(
+                state = listState,
+                userScrollEnabled = false,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                itemsIndexed(values) { index, item ->
+                    Chip(
+                        label = item.toString(),
+                        selected = selectedValueIndex.value == index,
+                        onClick = { selectedValueIndex.value = index },
+                    )
+                }
+            }
+        }
+
+        if (listState.canScrollForward || listState.canScrollBackward) {
+            LaunchedEffect(selectedValueIndex.value) {
+                listState.animateScrollToItem(selectedValueIndex.value)
+            }
+            ExpandChip(
+                onClick = { isSheetVisible = !isSheetVisible },
+            )
+        }
+    }
+
+    if (isSheetVisible) {
+        SelectionSheet(onDismissRequest = { isSheetVisible = false }, values, selectedValueIndex)
+    }
+
+    if (description != null && description.isNotBlank()) {
+        Gap(12.dp)
+        Text(
+            text = description,
+            style = currentTypography.parameterDescription,
+        )
+    }
+}
+
+@Suppress("ktlint:compose:mutable-state-param-check")
+@Composable
+private fun <T> SelectionSheet(
+    onDismissRequest: () -> Unit,
+    values: List<T>,
+    selectedValueIndex: MutableState<Int>,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = onDismissRequest,
+        containerColor = Color.White,
+        dragHandle = { StoryBottomSheetDragHandle() },
+        modifier = Modifier
+            .statusBarsPadding()
+            .padding(top = (24 * 2).dp),
+        contentWindowInsets = { WindowInsets.displayCutout },
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxHeight()
+                .selectableGroup(),
+            state = rememberLazyListState(),
+        ) {
+            itemsIndexed(values) { index, item ->
+                val selected = selectedValueIndex.value == index
+                CenterRow(
+                    modifier = Modifier
+                        .selectable(
+                            selected = selected,
+                            onClick = { selectedValueIndex.value = index },
+                            role = Role.RadioButton,
+                        )
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        modifier = Modifier.weight(1f),
+                        text = item.toString(),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = currentTypography.parameterText,
+                    )
+                    RadioButton(
+                        selected = selected,
+                        onClick = null,
+                        colors = RadioButtonDefaults.colors(
+                            currentColorScheme.primaryText,
+                            currentColorScheme.primaryText,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExpandChip(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val startPadding = 8.dp
+    Box(
+        modifier = modifier
+            .height(IntrinsicSize.Min)
+            .padding(start = startPadding),
+    ) {
+        Chip(
+            modifier = Modifier.semantics { role = Role.Button },
+            selected = false,
+            onClick = onClick,
+        ) {
+            Box {
+                Text("") // to match the height of the list item chips
+                Icon(
+                    painter = painterResource(Res.drawable.arrow_back),
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp).rotate(180f),
+                    tint = currentColorScheme.primaryText,
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .width(ShadowWidth)
+                .offset(x = -(ShadowWidth + startPadding))
+                .fillMaxHeight()
+                .background(Brush.horizontalGradient(listOf(Color.Transparent, Color.White))),
+        )
+    }
+}
+
+private val ShadowWidth = 18.dp

--- a/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/story/parameters/ParameterLabel.kt
+++ b/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/story/parameters/ParameterLabel.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -25,6 +26,8 @@ fun ParameterLabel(
         text = name,
         color = Color(0xFF64748B),
         fontSize = 12.sp,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
         modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
     )
 }

--- a/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/story/parameters/TextParameterField.kt
+++ b/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/story/parameters/TextParameterField.kt
@@ -31,8 +31,8 @@ fun <T> TextParameterField(
     state: MutableState<T>,
     toTypeOrNull: String.() -> T?,
     modifier: Modifier = Modifier,
-    label: String = "",
-    description: String = "",
+    label: String? = null,
+    description: String? = null,
 ) = Column {
     var number by state
     CenterRow {
@@ -41,7 +41,7 @@ fun <T> TextParameterField(
             style = currentTypography.parameterText,
         )
         Gap(6.dp)
-        ParameterLabel(label)
+        if (label != null && label.isNotBlank()) ParameterLabel(label)
     }
     Gap(12.dp)
     BasicTextField(
@@ -62,7 +62,7 @@ fun <T> TextParameterField(
             it()
         }
     }
-    if (description.isNotEmpty()) {
+    if (description != null && description.isNotBlank()) {
         Gap(12.dp)
         Text(
             text = description,

--- a/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/ui/component/Chip.kt
+++ b/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/ui/component/Chip.kt
@@ -1,0 +1,68 @@
+package org.jetbrains.compose.storytale.gallery.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.jetbrains.compose.storytale.gallery.compose.thenIf
+import org.jetbrains.compose.storytale.gallery.ui.theme.currentColorScheme
+import org.jetbrains.compose.storytale.gallery.ui.theme.currentTypography
+
+@Composable
+internal fun Chip(
+    label: String,
+    selected: Boolean,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    Chip(selected, onClick, modifier) {
+        Text(
+            text = label,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            fontSize = 14.sp,
+            color = if (selected) Color.White else currentColorScheme.primaryText,
+            style = currentTypography.parameterText,
+        )
+    }
+}
+
+@Composable
+internal fun Chip(
+    selected: Boolean,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val backgroundColor = if (selected) currentColorScheme.primaryText else Color.Transparent
+    val borderColor = if (selected) currentColorScheme.primaryText else currentColorScheme.primaryText.copy(alpha = 0.6f)
+    Box(
+        modifier = modifier
+            .heightIn(min = 32.dp)
+            .clip(ChipShape)
+            .thenIf(onClick != null) {
+                selectable(selected, role = Role.RadioButton, onClick = onClick!!)
+            }
+            .border(1.dp, borderColor, ChipShape)
+            .background(backgroundColor, ChipShape)
+            .padding(horizontal = 12.dp, vertical = 2.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
+private val ChipShape = RoundedCornerShape(8.dp)

--- a/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/ui/component/sheet/StoryBottomSheet.kt
+++ b/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/ui/component/sheet/StoryBottomSheet.kt
@@ -107,7 +107,7 @@ fun StoryBottomSheet(
 }
 
 @Composable
-private fun StoryBottomSheetDragHandle(
+internal fun StoryBottomSheetDragHandle(
     modifier: Modifier = Modifier,
     color: Color = Color(0xFFD2D7E6),
 ) = Spacer(

--- a/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/ui/component/sheet/StoryBottomSheetState.kt
+++ b/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/ui/component/sheet/StoryBottomSheetState.kt
@@ -53,9 +53,8 @@ class StoryBottomSheetState(
                         initialValue = it,
                         confirmValueChange = confirmValueChange,
                         skipPartiallyExpanded = skipPartiallyExpanded,
-                        positionalThreshold = { density.density },
-                        velocityThreshold = { density.density },
                         skipHiddenState = skipHiddenState,
+                        density = density,
                     ),
                     scope = scope,
                 )

--- a/modules/runtime-api/src/commonMain/kotlin/org/jetbrains/compose/storytale/Story.kt
+++ b/modules/runtime-api/src/commonMain/kotlin/org/jetbrains/compose/storytale/Story.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.compose.storytale
 
 import androidx.compose.runtime.Composable
+import kotlin.enums.enumEntries
 
 data class Story(
     val id: Int,
@@ -15,4 +16,13 @@ data class Story(
 
     @Composable
     inline fun <reified T> parameter(defaultValue: T) = StoryParameterDelegate(this, T::class, defaultValue)
+
+    @Composable
+    inline fun <reified T> parameter(values: List<T>, defaultValueIndex: Int = 0, label: String? = null) = StoryListParameterDelegate(this, T::class, values, defaultValueIndex, label)
+
+    @Composable
+    inline fun <reified T : Enum<T>> parameter(defaultValue: T): StoryListParameterDelegate<T> {
+        val enumEntries = enumEntries<T>()
+        return StoryListParameterDelegate(this, T::class, enumEntries, enumEntries.indexOf(defaultValue))
+    }
 }

--- a/modules/runtime-api/src/commonMain/kotlin/org/jetbrains/compose/storytale/StoryParameter.kt
+++ b/modules/runtime-api/src/commonMain/kotlin/org/jetbrains/compose/storytale/StoryParameter.kt
@@ -1,22 +1,12 @@
 package org.jetbrains.compose.storytale
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import kotlin.reflect.KClass
 
 class StoryParameter<T>(
     val name: String,
     val type: KClass<*>,
-    private val initializeMutableState: @Composable () -> MutableState<T>,
-) {
-    private var _state: MutableState<T>? = null
-    val state: MutableState<T>
-        @Composable get() {
-            var state = _state
-            if (state == null) {
-                state = initializeMutableState()
-                _state = state
-            }
-            return state
-        }
-}
+    val values: List<*>?,
+    val label: String?,
+    val state: MutableState<T>,
+)

--- a/modules/runtime-api/src/commonMain/kotlin/org/jetbrains/compose/storytale/StoryParameterDelegate.kt
+++ b/modules/runtime-api/src/commonMain/kotlin/org/jetbrains/compose/storytale/StoryParameterDelegate.kt
@@ -2,7 +2,6 @@ package org.jetbrains.compose.storytale
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
@@ -10,14 +9,38 @@ class StoryParameterDelegate<T>(
     private val story: Story,
     private val type: KClass<*>,
     private val defaultValue: T,
+    private val label: String? = null,
 ) {
     @Composable
     operator fun getValue(thisRef: Any?, property: KProperty<*>): T = story.nameToParameterMapping.getValue(property.name).state.value as T
 
+    // because put operation is only executed once
+    @Suppress("ktlint:compose:remember-missing-check")
     @Composable
     operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) = also {
         story.nameToParameterMapping.getOrPut(property.name) {
-            StoryParameter(property.name, type) { remember { mutableStateOf(defaultValue) } }
+            StoryParameter(property.name, type, values = null, label, mutableStateOf(defaultValue))
+        }
+    }
+}
+
+class StoryListParameterDelegate<T>(
+    private val story: Story,
+    private val type: KClass<*>,
+    private val list: List<T>,
+    private val defaultValueIndex: Int,
+    private val label: String? = null,
+) {
+    @Composable
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): T = list[story.nameToParameterMapping.getValue(property.name).state.value as Int]
+
+    // because put operation is only executed once
+    @Suppress("ktlint:compose:remember-missing-check")
+    @Composable
+    operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) = also {
+        story.nameToParameterMapping.getOrPut(property.name) {
+            require(list.isNotEmpty()) { "List cannot be empty" }
+            StoryParameter<Int>(property.name, type, list, label, mutableStateOf(defaultValueIndex))
         }
     }
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/fa284138-ae2e-448e-aec6-11a5a4d0804a

On Android
<img width="570" alt="storytale-list-parameter-android" src="https://github.com/user-attachments/assets/fc34b8d6-083e-43fd-80ff-22493ca6745c" />

-----------------

In this PR I added 2 new `parameter` functions: for arbitrary lists and for enums.

See their usage in the examples here: `PrimaryButton.story.kt`.

In the future, it will be possible to create many list-based pickers, such as for:
- icons
- text styles
- colors
- shapes
- etc

Also, API introduced in this PR allows users to create custom pickers for their data types, such as
- component styles
- sizes

I have manually tested these changes on android, desktop and web.

BTW community already [expressed](https://touchlab.co/previewing-storytale#:~:text=most%20surprisingly%20no%20enum%20support) the need for enum selection 🙂