### PR TITLE
Revert "fix: param settings FAB obstructs StoryContent (#68)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.2"
+agp = "8.7.1"
 android-compileSdk = "35"
 android-minSdk = "26"
 android-targetSdk = "35"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Fri May 02 19:34:04 ICT 2025
+#Tue Oct 29 23:06:22 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/compose/CompositionLocal.kt
+++ b/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/compose/CompositionLocal.kt
@@ -1,9 +1,5 @@
 package org.jetbrains.compose.storytale.gallery.compose
 
-import androidx.compose.runtime.staticCompositionLocalOf
-
 inline fun <reified T> noCompositionLocalProvided(): T {
     error("CompositionLocal ${T::class.simpleName} not present")
 }
-
-val LocalIsEmbeddedView = staticCompositionLocalOf { false }

--- a/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/material3/StorytaleGalleryApp.kt
+++ b/modules/gallery/src/commonMain/kotlin/org/jetbrains/compose/storytale/gallery/material3/StorytaleGalleryApp.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import org.jetbrains.compose.storytale.gallery.compose.LocalIsEmbeddedView
 import org.jetbrains.compose.storytale.gallery.ui.theme.LocalCustomDensity
 
 @Composable
@@ -30,7 +29,6 @@ fun StorytaleGalleryApp(
 
     CompositionLocalProvider(
         LocalCustomDensity provides Density(LocalDensity.current.density * 0.8f),
-        LocalIsEmbeddedView provides isEmbedded,
     ) {
         MaterialTheme(colorScheme = if (appState.isDarkTheme()) darkThemeColors else lightThemeColors) {
             if (isEmbedded) {

--- a/modules/runtime-api/src/commonMain/kotlin/org/jetbrains/compose/storytale/Story.kt
+++ b/modules/runtime-api/src/commonMain/kotlin/org/jetbrains/compose/storytale/Story.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.compose.storytale
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateMapOf
 import kotlin.enums.enumEntries
 
 data class Story(
@@ -12,7 +11,7 @@ data class Story(
     val content: @Composable Story.() -> Unit,
 ) {
     @PublishedApi
-    internal val nameToParameterMapping = mutableStateMapOf<String, StoryParameter<*>>()
+    internal val nameToParameterMapping = linkedMapOf<String, StoryParameter<*>>() // using linkedMap to keep the order
     val parameters inline get() = nameToParameterMapping.values.toList()
 
     inline fun <reified T> parameter(defaultValue: T) = StoryParameterDelegate(this, T::class, defaultValue)


### PR DESCRIPTION
This reverts commit 8a3a3103480ce26a0d2fec1818c24b7c0c110d5d.

Reasoning for reverting that change:
- the small FAB was intentionally used there according to the new gallery design. 

See the comments here: https://github.com/Kotlin/Storytale/pull/68#discussion_r2088492088